### PR TITLE
Fix VoiceOver description of A11yoop in preview app

### DIFF
--- a/Preview/A11yoopPreview/Main.swift
+++ b/Preview/A11yoopPreview/Main.swift
@@ -14,7 +14,10 @@ struct Main: View {
         NavigationView {
             VStack {
                 A11yFeatureStatusList(features: viewModel.features, lastUpdated: viewModel.lastUpdated)
-                    .navigationTitle("A11yoop Preview")
+                    .navigationTitle(
+                        Text("A11yoop Preview")
+                            .accessibilityLabel("Allyoop Preview")
+                    )
             }
         }
     }


### PR DESCRIPTION
# Description

Updated the accessibility label of the preview app's navigation title. This means that `A11yoop Preview` is now described correctly.

Fixes #3

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
