### PR TITLE
Improve the ergonomics of accessibility feature representation formatting for analytics

### DIFF
--- a/Preview/A11yoopPreview/MainViewModel.swift
+++ b/Preview/A11yoopPreview/MainViewModel.swift
@@ -36,7 +36,7 @@ final class MainViewModel: ObservableObject {
         )
 
         // Set initial features
-        features = monitor.features
+        features = monitor.allFeatures
         lastUpdated = Date()
     }
 }

--- a/Sources/A11yFeature/Extensions/A11yFeature+AsAnalyticsParams.swift
+++ b/Sources/A11yFeature/Extensions/A11yFeature+AsAnalyticsParams.swift
@@ -8,6 +8,11 @@ import Foundation
 extension Sequence where Element == A11yFeature {
 
     /// An adapter that returns a dictionary representation of accessibility features in a format commonly supported by analytics SDK APIs.
+    ///
+    /// - Parameter prefix: An optional prefix to apply to every param key that is outputted in order to prevent name collisions.
+    ///
+    /// - Returns: The dictionary representation.
+    ///
     public func asAnalyticsParams(prefixedBy prefix: String? = nil) -> [String: Any] {
         reduce(into: [String: Any]()) { $0[formatKey(using: $1, prefixedBy: prefix)] = $1.status.description }
     }

--- a/Sources/A11yFeature/Extensions/A11yStatus+IsDisabled.swift
+++ b/Sources/A11yFeature/Extensions/A11yStatus+IsDisabled.swift
@@ -1,0 +1,15 @@
+//
+//  A11yStatus+IsDisabled.swift
+//  Copyright © 2021 Notonthehighstreet Enterprises Limited. All rights reserved.
+//
+
+import Foundation
+
+extension A11yStatus {
+
+    /// Whether or not the accessibility feature is considered to be disabled.
+    public var isDisabled: Bool {
+        guard case .disabled = self else { return false }
+        return true
+    }
+}

--- a/Sources/A11yFeature/Extensions/A11yStatus+IsEnabled.swift
+++ b/Sources/A11yFeature/Extensions/A11yStatus+IsEnabled.swift
@@ -1,0 +1,22 @@
+//
+//  A11yStatus+IsEnabled.swift
+//  Copyright © 2021 Notonthehighstreet Enterprises Limited. All rights reserved.
+//
+
+import Foundation
+
+extension A11yStatus {
+
+    /// Whether or not the accessibility feature is considered to be enabled.
+    public var isEnabled: Bool {
+        if case .enabled = self {
+            return true
+        }
+
+        if case .contentSize = self {
+            return true
+        }
+
+        return false
+    }
+}

--- a/Sources/A11yFeature/Extensions/A11yStatus+IsNotSupported.swift
+++ b/Sources/A11yFeature/Extensions/A11yStatus+IsNotSupported.swift
@@ -1,0 +1,15 @@
+//
+//  A11yStatus+isNotSupported.swift
+//  Copyright © 2021 Notonthehighstreet Enterprises Limited. All rights reserved.
+//
+
+import Foundation
+
+extension A11yStatus {
+
+    /// Whether or not the accessibility feature is considered to be not supported.
+    public var isNotSupported: Bool {
+        guard case .notSupported = self else { return false }
+        return true
+    }
+}

--- a/Sources/A11yoopMonitor/A11yoopMonitor.swift
+++ b/Sources/A11yoopMonitor/A11yoopMonitor.swift
@@ -15,8 +15,17 @@ import A11yStatusProvider
 /// Allows accessibility features that users have enabled on their iOS devices to be tracked as they are enabled and disabled.
 public struct A11yoopMonitor {
 
-    /// A list of accessibility features that are currently being monitored. These contain up-to-date statuses for each accessibility feature.
-    public var features: [A11yFeature] { _monitor.featuresSubject.value }
+    /// A list of all accessibility features that are currently being monitored. These contain up-to-date statuses for each accessibility feature.
+    public var allFeatures: [A11yFeature] { _monitor.featuresSubject.value }
+
+    /// A list of accessibility features that are currently being monitored that are considered to be enabled. These contain up-to-date statuses for each accessibility feature.
+    public var enabledFeatures: [A11yFeature] { allFeatures.filter(\.status.isEnabled) }
+
+    /// A list of accessibility features that are currently being monitored that are considered to be disabled. These contain up-to-date statuses for each accessibility feature.
+    public var disabledFeatures: [A11yFeature] { allFeatures.filter(\.status.isDisabled) }
+
+    /// A list of accessibility features that are currently being monitored that are considered not to be supported. These contain up-to-date statuses for each accessibility feature.
+    public var unsupportedFeatures: [A11yFeature] { allFeatures.filter(\.status.isNotSupported) }
 
     /// The internal underlying monitor instance.
     let _monitor: A11yMonitor

--- a/Tests/A11yFeatureTests/Extension Tests/A11yStatus+IsDisabledTests.swift
+++ b/Tests/A11yFeatureTests/Extension Tests/A11yStatus+IsDisabledTests.swift
@@ -1,0 +1,28 @@
+//
+//  A11yStatus+IsDisabledTests.swift
+//  Copyright © 2021 Notonthehighstreet Enterprises Limited. All rights reserved.
+//
+
+import XCTest
+import A11yFeature
+
+final class A11yStatus_IsDisabledTests: XCTestCase {
+
+    func test_isDisabledWhenTrue() {
+
+        let disabled: A11yStatus = .disabled
+
+        XCTAssertTrue(disabled.isDisabled)
+    }
+
+    func test_isDisabledWhenFalse() {
+
+        let enabled: A11yStatus = .enabled
+        let contentSize: A11yStatus = .contentSize(.medium)
+        let notSupported: A11yStatus = .notSupported
+
+        XCTAssertFalse(enabled.isDisabled)
+        XCTAssertFalse(contentSize.isDisabled)
+        XCTAssertFalse(notSupported.isDisabled)
+    }
+}

--- a/Tests/A11yFeatureTests/Extension Tests/A11yStatus+IsEnabledTests.swift
+++ b/Tests/A11yFeatureTests/Extension Tests/A11yStatus+IsEnabledTests.swift
@@ -1,0 +1,33 @@
+//
+//  A11yStatus+IsEnabledTests.swift
+//  Copyright © 2021 Notonthehighstreet Enterprises Limited. All rights reserved.
+//
+
+import XCTest
+import A11yFeature
+
+final class A11yStatus_IsEnabledTests: XCTestCase {
+
+    func test_isEnabledWhenTrue() {
+
+        let enabled: A11yStatus = .enabled
+
+        XCTAssertTrue(enabled.isEnabled)
+    }
+
+    func test_isEnabledWhenContentSize() {
+
+        let contentSize: A11yStatus = .contentSize(.medium)
+
+        XCTAssertTrue(contentSize.isEnabled)
+    }
+
+    func test_isEnabledWhenFalse() {
+
+        let disabled: A11yStatus = .disabled
+        let notSupported: A11yStatus = .notSupported
+
+        XCTAssertFalse(disabled.isEnabled)
+        XCTAssertFalse(notSupported.isEnabled)
+    }
+}

--- a/Tests/A11yFeatureTests/Extension Tests/A11yStatus+IsNotSupportedTests.swift
+++ b/Tests/A11yFeatureTests/Extension Tests/A11yStatus+IsNotSupportedTests.swift
@@ -1,0 +1,28 @@
+//
+//  A11yStatus+NotSupportedTests.swift
+//  Copyright © 2021 Notonthehighstreet Enterprises Limited. All rights reserved.
+//
+
+import XCTest
+import A11yFeature
+
+final class A11yStatus_IsNotSupportedTests: XCTestCase {
+
+    func test_notSupportedWhenTrue() {
+
+        let notSupported: A11yStatus = .notSupported
+
+        XCTAssertTrue(notSupported.isNotSupported)
+    }
+
+    func test_notSupportedWhenFalse() {
+
+        let enabled: A11yStatus = .enabled
+        let contentSize: A11yStatus = .contentSize(.medium)
+        let disabled: A11yStatus = .disabled
+
+        XCTAssertFalse(enabled.isNotSupported)
+        XCTAssertFalse(contentSize.isNotSupported)
+        XCTAssertFalse(disabled.isNotSupported)
+    }
+}

--- a/Tests/A11yoopMonitorIntegrationTests/A11yoopMonitorIntegrationTests.swift
+++ b/Tests/A11yoopMonitorIntegrationTests/A11yoopMonitorIntegrationTests.swift
@@ -134,7 +134,7 @@ final class A11yoopMonitorIntegrationTests: XCTestCase {
 
         sut = A11yoopMonitor(queue: .immediate)
 
-        let status = try XCTUnwrap(sut.features.first { $0.type == featureType }?.status)
+        let status = try XCTUnwrap(sut.allFeatures.first { $0.type == featureType }?.status)
 
         XCTAssertEqual(status, expectedStatus)
     }


### PR DESCRIPTION
# Description

It is not always the case that users will want to represent a sequence of `A11yFeature` as a params dictionary (using the `asAnalyticsParams(prefixedBy:)` adapter) for analytics purposes. They may want, for example, only a subset of the enabled features listed as a comma-separated String. Previously, this would require a lot of extra work for the user to filter `features` provided by the `A11yoopMonitor` and then format them in whatever way is needed.

While it does not seem beneficial for A11yoop to attempt to provide convenience methods to format `A11yFeature` in x number of ways, it would be worth extending `A11yoopMonitor` to provide some additional properties for currently monitored accessibility features that are enabled, disabled and unsupported. This would then allow the user to take that information and format it in whichever way they require (using the `asAnalyticsParams(prefixedBy:)` adapter, comma-separated or otherwise).

For example, if a user wished to include enabled features as a comma-separated String in order to include this in any analytics events that they were already sending, it does not make sense to pollute the payload with accessibility features as key-value pairs (ie. using the `asAnalyticsParams(prefixedBy:)` adapter). Instead, it would be better to have easy access to a list of enabled features that they could format accordingly.

This is now possible, so a user is now able to do the following:
```swift

let monitor = A11yoopMonitor()

let formattedEnabledFeatures =  monitor.enabledFeatures.map(\.type.description).joined(separator: ",")

let formattedDisabledFeatures = monitor.disabledFeatures.map(\.type.description).joined(separator: ",")

let formattedUnsupportedFeatures = monitor.unsupportedFeatures.map(\.type.description).joined(separator: ",")

```

This improves the ergonomics around formatting accessibility feature representations and eliminates any additional filtering on the consumer side. Of course, it is still possible to access all accessibility features that are currently being monitored. However, this property has been updated from `features` to `allFeatures` and it is worth noting that this is a breaking change.

Fixes #9 

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Added unit tests, ensured preview app is still functioning, manual testing.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
