### PR TITLE
Add notMonitored status and update isFeatureEnabled method signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,15 +38,15 @@ Once you have instantiated `A11yoopMonitor`, it is possible to query the current
 let monitor = A11yoopMonitor(featureTypes: [.voiceOver, ...])
 
 // In order to query current status of voice over accessibility feature
-let isEnabled = monitor.isFeatureEnabled(.voiceOver)
+let status = monitor.isFeatureEnabled(.voiceOver)
 ```
 
-Note that it is only possible to query the status of accessibility features that are currently being monitored. Doing the following would therefore always result in `.disabled`:
+When querying the status of an accessibility feature that is not currently being monitored, the resulting status will be `.notMonitored`.
 ```swift
 let monitor = A11yoopMonitor(featureTypes: [.voiceOver]) // Only monitors voice over
 
-let isEnabled = monitor.isFeatureEnabled(.boldText) // Query an accessibility feature that isn't monitored
-/// - false
+let status = monitor.isFeatureEnabled(.boldText) // Query an accessibility feature that isn't monitored
+/// - .notMonitored
 ```
 
 Finally, if an accessibility feature that you are monitoring is not currently supported on a user's device, the status is returned as `.notSupported`.

--- a/Sources/A11yFeature/A11yStatus.swift
+++ b/Sources/A11yFeature/A11yStatus.swift
@@ -19,16 +19,20 @@ public enum A11yStatus: Equatable {
 
     /// The accessibility feature is not supported on the current device.
     case notSupported
+
+    /// The accessibility feature is not currently being monitored
+    case notMonitored
 }
 
 extension A11yStatus: CustomStringConvertible {
 
     public var description: String {
         switch self {
-        case .enabled:  return "Enabled"
-        case .disabled: return "Disabled"
-        case .contentSize(let size): return size.description
-        case .notSupported: return "Not Supported"
+        case .enabled:                  return "Enabled"
+        case .disabled:                 return "Disabled"
+        case .contentSize(let size):    return size.description
+        case .notSupported:             return "Not Supported"
+        case .notMonitored:             return "Not Monitored"
         }
     }
 }

--- a/Sources/A11yMonitor/Interface.swift
+++ b/Sources/A11yMonitor/Interface.swift
@@ -19,11 +19,11 @@ public struct A11yMonitor {
     ///
     /// - Returns: A boolean value that indicates whether or not the accessibility feature is currently enabled.
     ///
-    public let isFeatureEnabled: (_ feature: A11yFeatureType) -> Bool
+    public let isFeatureEnabled: (_ feature: A11yFeatureType) -> A11yStatus
 
     public init(
         featuresSubject: CurrentValueSubject<[A11yFeature], Never>,
-        isFeatureEnabled: @escaping (A11yFeatureType) -> Bool
+        isFeatureEnabled: @escaping (A11yFeatureType) -> A11yStatus
     ) {
         self.featuresSubject = featuresSubject
         self.isFeatureEnabled = isFeatureEnabled

--- a/Sources/A11yStatusObserver/Interface.swift
+++ b/Sources/A11yStatusObserver/Interface.swift
@@ -24,11 +24,11 @@ public struct A11yStatusObserver {
     ///
     /// - Returns: A boolean value that indicates whether or not the accessibility feature is currently enabled.
     ///
-    public let isFeatureEnabled: (_ featureType: A11yFeatureType) -> Bool
+    public let isFeatureEnabled: (_ featureType: A11yFeatureType) -> A11yStatus
 
     public init(
         observeFeatures: @escaping (_ features: [A11yFeature], _ emitters: [A11yStatusEmitter]) -> Void,
-        isFeatureEnabled: @escaping (_ featureType: A11yFeatureType) -> Bool
+        isFeatureEnabled: @escaping (_ featureType: A11yFeatureType) -> A11yStatus
     ) {
         self.observeFeatures = observeFeatures
         self.isFeatureEnabled = isFeatureEnabled

--- a/Sources/A11yStatusObserverLive/Live.swift
+++ b/Sources/A11yStatusObserverLive/Live.swift
@@ -55,10 +55,10 @@ extension A11yStatusObserver {
             },
             isFeatureEnabled: { featureType in
                 guard let feature = featureStore.get(featureType) else {
-                    return false
+                    return .notMonitored
                 }
 
-                return feature.status == .enabled
+                return feature.status
             }
         )
     }

--- a/Sources/A11yoopMonitor/A11yoopMonitor.swift
+++ b/Sources/A11yoopMonitor/A11yoopMonitor.swift
@@ -62,7 +62,7 @@ public struct A11yoopMonitor {
     ///
     /// - Returns: A boolean value that indicates whether or not the accessibility feature is currently enabled.
     ///
-    public func isFeatureEnabled(_ featureType: A11yFeatureType) -> Bool {
+    public func isFeatureEnabled(_ featureType: A11yFeatureType) -> A11yStatus {
         _monitor.isFeatureEnabled(featureType)
     }
 }

--- a/Tests/A11yFeatureTests/A11yStatus+DescriptionTests.swift
+++ b/Tests/A11yFeatureTests/A11yStatus+DescriptionTests.swift
@@ -29,4 +29,9 @@ final class A11yStatus_DescriptionTests: XCTestCase {
 
         XCTAssertEqual(sut.notSupported.description, "Not Supported")
     }
+
+    func test_descriptionForNotMonitored() {
+
+        XCTAssertEqual(sut.notMonitored.description, "Not Monitored")
+    }
 }

--- a/Tests/A11yMonitorTests/A11yMonitorTests.swift
+++ b/Tests/A11yMonitorTests/A11yMonitorTests.swift
@@ -1,5 +1,5 @@
 //
-//  A11yoopMonitorTests.swift
+//  A11yMonitorTests.swift
 //  Copyright © 2021 Notonthehighstreet Enterprises Limited. All rights reserved.
 //
 
@@ -11,7 +11,7 @@ import A11yStatusEmitter
 import A11yMonitor
 import A11yMonitorLive
 
-final class A11yoopMonitorTests: XCTestCase {
+final class A11yMonitorTests: XCTestCase {
 
     private var sut: A11yMonitor!
 

--- a/Tests/A11yMonitorTests/A11yoopMonitorTests.swift
+++ b/Tests/A11yMonitorTests/A11yoopMonitorTests.swift
@@ -27,7 +27,7 @@ final class A11yoopMonitorTests: XCTestCase {
                 output.append(contentsOf: features)
                 didInvokeStatusManager = true
             },
-            isFeatureEnabled: { _ in XCTFail(); return false }
+            isFeatureEnabled: { _ in XCTFail(); return .disabled }
         )
 
         sut = .live(
@@ -51,7 +51,7 @@ final class A11yoopMonitorTests: XCTestCase {
             isFeatureEnabled: { type in
                 output.append(type)
                 didInvokeStatusManager = true
-                return true
+                return .enabled
             }
         )
 
@@ -62,7 +62,7 @@ final class A11yoopMonitorTests: XCTestCase {
             statusProvider: .enabled
         )
 
-        XCTAssertTrue(sut.isFeatureEnabled(try XCTUnwrap(featureTypes.first)))
+        XCTAssertEqual(sut.isFeatureEnabled(try XCTUnwrap(featureTypes.first)), .enabled)
 
         XCTAssertTrue(didInvokeStatusManager)
         XCTAssertEqual(output, [try XCTUnwrap(featureTypes.first)])

--- a/Tests/A11yStatusObserverTests/A11yStatusObserverTests.swift
+++ b/Tests/A11yStatusObserverTests/A11yStatusObserverTests.swift
@@ -74,7 +74,7 @@ final class A11yStatusObserverTests: XCTestCase {
 
         sut = .live(featureStore: store, notificationCenter: notificationCenter, queue: queue)
 
-        XCTAssertTrue(sut.isFeatureEnabled(.voiceOver))
+        XCTAssertEqual(sut.isFeatureEnabled(.voiceOver), .enabled)
     }
 
     func test_isFeatureEnabledWhenFeatureDisabled() {
@@ -85,7 +85,7 @@ final class A11yStatusObserverTests: XCTestCase {
 
         sut = .live(featureStore: store, notificationCenter: notificationCenter, queue: queue)
 
-        XCTAssertFalse(sut.isFeatureEnabled(.voiceOver))
+        XCTAssertEqual(sut.isFeatureEnabled(.voiceOver), .disabled)
     }
 
     func test_isFeatureEnabledWhenFeatureNotInFeatureStore() {
@@ -95,7 +95,7 @@ final class A11yStatusObserverTests: XCTestCase {
 
         sut = .live(featureStore: store, notificationCenter: notificationCenter, queue: queue)
 
-        XCTAssertFalse(sut.isFeatureEnabled(.voiceOver))
+        XCTAssertEqual(sut.isFeatureEnabled(.voiceOver), .notMonitored)
     }
 
     // MARK: - Multiple emitter tests

--- a/Tests/A11yoopMonitorTests/A11yoopMonitorTests.swift
+++ b/Tests/A11yoopMonitorTests/A11yoopMonitorTests.swift
@@ -179,7 +179,7 @@ final class A11yoopMonitorTests: XCTestCase {
             featuresSubject: .init([]),
             isFeatureEnabled: {
                 output.append($0)
-                return false
+                return .disabled
             }
         )
 


### PR DESCRIPTION
# Description

- Added a new `notMonitored` status to `A11yStatus` enum.
- Updated the `isFeatureEnabled` method to return an `A11yStatus` instead of a boolean.
- Renamed duplicate `A11yoopMonitorTests` to `A11yMonitorTests` in order to avoid confusion.
- Updated README.

Fixes #16 

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

Added unit tests that assert the desired functionality.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
